### PR TITLE
Fixed error code checking for Win32 systems

### DIFF
--- a/src/shlibpp/SharedLibraryClassApi.h
+++ b/src/shlibpp/SharedLibraryClassApi.h
@@ -40,7 +40,7 @@ extern "C" {
 
         using createFn_t = void*(*)();
         using destroyFn_t = void(*)(void*);
-        using getFn_t = int32_t(*)(char*, size_t);
+        using getFn_t = size_t(*)(char*, size_t);
 
         createFn_t create;        // Instantiate a plugin object.
         destroyFn_t destroy;      // Destroy a plugin object.
@@ -114,24 +114,24 @@ constexpr int32_t SHLIBPP_DEFAULT_SYSTEM_VERSION = 5;
         } \
     } \
     \
-    SHLIBPP_SHARED_CLASS_FN int32_t factoryname ## _getVersion (char* ver, size_t len) \
+    SHLIBPP_SHARED_CLASS_FN size_t factoryname ## _getVersion (char* ver, size_t len) \
     { \
         return 0; \
     } \
     \
-    SHLIBPP_SHARED_CLASS_FN int32_t factoryname ## _getAbi (char* abi, size_t len) \
+    SHLIBPP_SHARED_CLASS_FN size_t factoryname ## _getAbi (char* abi, size_t len) \
     { \
         return 0; \
     } \
     \
-    SHLIBPP_SHARED_CLASS_FN int32_t factoryname ## _getClassName (char* name, size_t len) \
+    SHLIBPP_SHARED_CLASS_FN size_t factoryname ## _getClassName (char* name, size_t len) \
     { \
         char cname[] = # classname; \
         strncpy(name, cname, len); \
         return strlen(cname) + 1; \
     } \
     \
-    SHLIBPP_SHARED_CLASS_FN int32_t factoryname ## _getBaseClassName (char* name, size_t len) \
+    SHLIBPP_SHARED_CLASS_FN size_t factoryname ## _getBaseClassName (char* name, size_t len) \
     { \
         char cname[] = # basename; \
         strncpy(name, cname, len); \

--- a/src/shlibpp/SharedLibraryFactory.h
+++ b/src/shlibpp/SharedLibraryFactory.h
@@ -14,7 +14,7 @@
 
 namespace shlibpp {
 
-class SharedLibraryClassApi;
+struct SharedLibraryClassApi;
 
 /**
  * A wrapper for a named factory method in a named shared library.


### PR DESCRIPTION
I came across your code here: https://www.reddit.com/r/cpp/comments/9c9kqz/do_cpp_users_wantneed_a_cross_platform_framework/e5ag74p

I've been stepping through it to learn about loading shared libraries and came across a possible error. FreeLibrary returns non-zero results on success, while dlclose() returns 0 on success. Also, it looks like the code always gets an error message and sets it, even if loading/unloading the shared library was successful. 